### PR TITLE
Add feature to safely use non-subgraph APIs with Subgrounds

### DIFF
--- a/examples/olympus_voting.py
+++ b/examples/olympus_voting.py
@@ -1,0 +1,123 @@
+from datetime import datetime
+from random import choice
+
+import dash
+from dash import html
+
+from subgrounds.dash_wrappers import Graph
+from subgrounds.plotly_wrappers import Figure, Scatter, Indicator
+from subgrounds.schema import TypeRef
+from subgrounds.subgraph import SyntheticField
+from subgrounds.subgrounds import Subgrounds
+
+
+sg = Subgrounds()
+olympusDAO = sg.load_subgraph('https://api.thegraph.com/subgraphs/name/drondin/olympus-protocol-metrics')
+snapshot = sg.load_api('https://hub.snapshot.org/graphql')
+
+# Define useful synthetic fields
+olympusDAO.ProtocolMetric.datetime = SyntheticField(
+  lambda timestamp: str(datetime.fromtimestamp(timestamp)),
+  SyntheticField.STRING,
+  olympusDAO.ProtocolMetric.timestamp,
+)
+
+protocol_metrics_1year = olympusDAO.Query.protocolMetrics(
+  orderBy=olympusDAO.ProtocolMetric.timestamp,
+  orderDirection='desc',
+  first=365
+)
+
+snapshot.Proposal.datetime = SyntheticField(
+  lambda timestamp: str(datetime.fromtimestamp(timestamp)),
+  SyntheticField.STRING,
+  snapshot.Proposal.end,
+)
+
+
+def fmt_summary(title, choices, scores):
+  total_vote = sum(scores)
+  vote_string = '<br>'.join(f'{choice}: {100*score/total_vote:.2f}%' for choice, score in zip(choices, scores))
+  return f'{title}<br>{vote_string}'
+
+
+snapshot.Proposal.summary = SyntheticField(
+  fmt_summary,
+  SyntheticField.STRING,
+  [
+    snapshot.Proposal.title,
+    snapshot.Proposal.choices,
+    snapshot.Proposal.scores
+  ],
+)
+
+proposals = snapshot.Query.proposals(
+  orderBy='created',
+  orderDirection='desc',
+  first=100,
+  where=[
+    snapshot.Proposal.space == 'olympusdao.eth',
+    snapshot.Proposal.state == 'closed'
+  ]
+)
+
+# Dashboard
+app = dash.Dash(__name__)
+
+app.layout = html.Div(
+  html.Div([
+    html.H4('Entities'),
+    html.Div([
+      Graph(Figure(
+        subgrounds=sg,
+        traces=[
+          Scatter(
+            x=proposals.datetime,
+            y=proposals.votes,
+            text=proposals.summary,
+            name='proposals',
+            mode='markers',
+          ),
+          Scatter(
+            x=protocol_metrics_1year.datetime,
+            y=protocol_metrics_1year.marketCap,
+            name='treasury_market_value',
+            yaxis='y2',
+          )
+        ],
+        layout={
+          'showlegend': True,
+          'hovermode': 'x',
+          'spikedistance': -1,
+          'xaxis': {
+            'showspikes': True,
+            'spikedash': 'solid',
+            'spikemode': 'across+toaxis',
+            'spikesnap': 'cursor',
+            'spikecolor': 'black',
+            'spikethickness': 1,
+            'showline': True,
+            'showgrid': True
+          },
+          'yaxis': {
+            'title': 'Proposals',
+            'titlefont': {'color': '#1f77b4'},
+            'tickfont': {'color': '#ffffff'},
+          },
+          'yaxis2': {
+            'title': 'Treasury Market Value',
+            'titlefont': {'color': '#ff7f0e'},
+            'tickfont': {'color': '#ff7f0e'},
+            'anchor': 'free',
+            'overlaying': 'y',
+            'side': 'left',
+            'position': 0.05,
+          },
+        }
+      ))
+    ])
+  ])
+)
+
+if __name__ == '__main__':
+  app.run_server(debug=True)

--- a/subgrounds/subgraph.py
+++ b/subgrounds/subgraph.py
@@ -22,7 +22,7 @@ import warnings
 import subgrounds.client as client
 from subgrounds.query import Query, Selection, arguments_of_field_args
 from subgrounds.schema import SchemaMeta, TypeMeta, TypeRef, mk_schema
-from subgrounds.transform import DEFAULT_GLOBAL_TRANSFORMS, LocalSyntheticField, DocumentTransform
+from subgrounds.transform import DEFAULT_SUBGRAPH_TRANSFORMS, LocalSyntheticField, DocumentTransform
 from subgrounds.utils import extract_data, identity
 
 logger = logging.getLogger('subgrounds')
@@ -672,10 +672,11 @@ class Subgraph:
   url: str
   schema: SchemaMeta
   transforms: list[DocumentTransform] = field(default_factory=list)
+  is_subgraph: bool = True
 
   # TODO: Remove
   @staticmethod
-  def of_url(url: str) -> None:
+  def of_url(url: str) -> Subgraph:
     warnings.warn("`of_url` will be deprecated! Use `Subgrounds`'s `load_subgraph` instead", DeprecationWarning)
     filename = url.split("/")[-1] + ".json"
     if os.path.isfile(filename):
@@ -686,7 +687,7 @@ class Subgraph:
       with open(filename, mode="w") as f:
         json.dump(schema, f)
 
-    return Subgraph(url, mk_schema(schema), DEFAULT_GLOBAL_TRANSFORMS)
+    return Subgraph(url, mk_schema(schema), DEFAULT_SUBGRAPH_TRANSFORMS)
 
   def add_synthetic_field(
     self,


### PR DESCRIPTION
subgrounds.subgrounds:
- Add new method `Subgrounds.load_api` to load non-subgraph APIs
- Add new argument `auto_paginate` to `Subgrounds.query_json`,
  `Subgrounds.query`, `Subgrounds.query_df` and `Subgrounds.execute` to
  selectively disable automatic pagination at will

subgrounds.subgraph:
- Add new attribute `is_subgraph` to `Subgraph` class

examples:
- Add new non-subgraph example